### PR TITLE
Fix issue caused when the start date of month is Monday

### DIFF
--- a/src/cal.js
+++ b/src/cal.js
@@ -48,7 +48,12 @@ export default class Cal {
         const thisFirstDay = DAY_STR[thisFirstDateObj.getDay()];
         const thisLastDate = thisLastDateObj.getDate();
 
-        const thisFirstDayIdx = DAY_STR.indexOf(thisFirstDay) - 1 - GAP;
+        const thisFirstDayIdx = (() => {
+            const index = DAY_STR.indexOf(thisFirstDay)
+            // その月の1日が日曜日かつ設定が月曜始まりの場合、
+            // 前月の最終月曜から出力しなければならないため、5を返す
+            return (index === 0 && GAP === 1) ? 5 : index - 1 - GAP
+        })();
 
         // 今月が1月なら、先月は12月で去年になる
         const mayLastYear = (thisMonth === 1) ? thisYear - 1 : thisYear;

--- a/src/cal.js
+++ b/src/cal.js
@@ -49,10 +49,10 @@ export default class Cal {
         const thisLastDate = thisLastDateObj.getDate();
 
         const thisFirstDayIdx = (() => {
-            const index = DAY_STR.indexOf(thisFirstDay)
+            const index = DAY_STR.indexOf(thisFirstDay);
             // その月の1日が日曜日かつ設定が月曜始まりの場合、
             // 前月の最終月曜から出力しなければならないため、5を返す
-            return (index === 0 && GAP === 1) ? 5 : index - 1 - GAP
+            return (index === 0 && GAP === 1) ? 5 : index - 1 - GAP;
         })();
 
         // 今月が1月なら、先月は12月で去年になる


### PR DESCRIPTION
Hi.

**Before**

```
const cal = new Cal({year: 2017, month: 1, date: 1, fromMonday: true});
cal.getCalArr()[0].YYYYMMDD; // 20170102 Hmm... Jan 1 is not displayed.
```

**Fixed**

```
const cal = new Cal({year: 2017, month: 1, date: 1, fromMonday: true});
cal.getCalArr()[0].YYYYMMDD; // 20161226
cal.getCalArr()[6].YYYYMMDD; // 20170101 Good.
```

Thanks.